### PR TITLE
Allow Body to be Function (SWS-4898)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Template strings that are compatible with [handlebars](https://handlebarsjs.com/
 
 If the rendered template is valid JSON, the response will be of type `application/json`.
 
+Also, be aware that instead of a direct JSON response, the body can also be a function that takes in a `RequestParameters` and returns a body response. The response will still be processed through handlebars.
+
 ### Routes
 * `GET /` returns all of the currently defined routes 
 * `POST /` Takes a `RuntimeRequestBody` and adds it to the collection or updates the existing entry if it exists.

--- a/src/appV2.test.ts
+++ b/src/appV2.test.ts
@@ -251,9 +251,9 @@ describe('Body as Function', () => {
                     GET: {
                         body: function(rp: RequestParameters) {
                             if(rp.query.id == "2") {
-                                return "id was 2";
+                                return {id: 2};
                             } else {
-                                return "id was not 2";
+                                return {id: 3};
                             }
                         },
                         status: 200
@@ -267,11 +267,11 @@ describe('Body as Function', () => {
 
         var response = await request(app).get('/test?id=2');
 
-        expect(response.text).toEqual("id was 2");
+        expect(response.body).toEqual({id: 2});
 
         var secondResponse = await request(app).get('/test?id=3');
 
-        expect(secondResponse.text).toEqual("id was not 2");
+        expect(secondResponse.body).toEqual({id: 3});
     })
 });
 

--- a/src/appV2.test.ts
+++ b/src/appV2.test.ts
@@ -1,5 +1,5 @@
 import request from 'supertest';
-import { appFactory, isRuntimeRequestCollection, RuntimeRequestBody, RuntimeRequestCollection, SupportedMethodsColection } from './appV2';
+import { appFactory, isRuntimeRequestCollection, RuntimeRequestBody, RuntimeRequestCollection, SupportedMethodsColection, RequestParameters } from './appV2';
 
 describe('appFactory', () => {
     test('Creates app with no seed', () => {
@@ -240,6 +240,39 @@ describe('METHOD /*', () => {
 
         expect(response.body).toEqual({ id })
     });
+});
+
+describe('Body as Function', () => {
+    test('executes the method for the result', async () => {
+        const seed: RuntimeRequestCollection = {
+            "/test": {
+                path: "/test",
+                methods: {
+                    GET: {
+                        body: function(rp: RequestParameters) {
+                            if(rp.query.id == "2") {
+                                return "id was 2";
+                            } else {
+                                return "id was not 2";
+                            }
+                        },
+                        status: 200
+                    }
+                }
+            }
+        }
+
+        const app = appFactory(seed);
+        expect(app).toBeDefined();
+
+        var response = await request(app).get('/test?id=2');
+
+        expect(response.text).toEqual("id was 2");
+
+        var secondResponse = await request(app).get('/test?id=3');
+
+        expect(secondResponse.text).toEqual("id was not 2");
+    })
 });
 
 describe('isRuntimeRequestMethodBodyCollection', () => {

--- a/src/appV2.ts
+++ b/src/appV2.ts
@@ -40,6 +40,13 @@ export interface RuntimeRequestMethodBody {
     headers?: Record<string, string>;
 }
 
+export interface RequestParameters {
+    query: any,
+    params: any,
+    body: any,
+    headers: any
+}
+
 export const isRuntimeRequestMethodBody = (obj: any): obj is RuntimeRequestMethodBody => {
     try {
         return !!obj.body && (!obj.status || !isNaN(Number(obj.status)))
@@ -202,7 +209,12 @@ export const appFactory = (runtimeCollection?: RuntimeRequestCollection) => {
                 res.set(processedHeaders);
             }
 
-            const { body } = method;
+            let { body } = method;
+
+            // if body is a function, execute and then process the response
+            if (typeof body === 'function') {
+                body = body(tokenParams);
+            }
 
             if (typeof body !== 'string') {
                 return res.send(body);


### PR DESCRIPTION
Motivation
---
 - In short, after researching how to handle different data for query params and data, I'd like to propose that we allow the body parameter to be a function
 - This means, instead of limiting path by id (more difficult), we could instead have the base path and then just a function on the body that dictates what needs to change based on requested parameters.

Modification
---
 - Updated the appV2 to support the body parameter to be a function
 - Added a test to validate it executes correctly

https://centeredge.atlassian.net/browse/SWS-4898
