### PR TITLE
Remove Version Update and Update Package to 2.3.0 (SWS-4906)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -29,7 +29,6 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm run build
-      - run: npm version from-git --allow-same-version
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@centeredgesoft/runtime-mock-routes",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centeredgesoft/runtime-mock-routes",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "",
   "main": "build/index.js",
   "scripts": {


### PR DESCRIPTION
Motivation
---
 - I'd like to get this out there so I can use it
 - Looks like with GitHub actions, they've designed it such that the package.json should always match the latest release (no easy way to pull the version number from the release tag)

Modification
---
 - Removed npm version command
 - Updated to 2.3.0

https://centeredge.atlassian.net/browse/SWS-4906
