### PR TITLE
Allow Simple Types in Request (SWS-4913)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@centeredgesoft/runtime-mock-routes",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centeredgesoft/runtime-mock-routes",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "",
   "main": "build/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "homepage": "https://github.com/CenterEdge/runtime-mock-routes#readme",
   "dependencies": {
-    "body-parser": "^1.19.0",
     "chance": "^1.1.7",
     "commander": "^6.2.1",
     "cors": "^2.8.5",
@@ -35,7 +34,6 @@
     "sort-keys": "^4.2.0"
   },
   "devDependencies": {
-    "@types/body-parser": "^1.19.0",
     "@types/chance": "^1.1.1",
     "@types/cors": "^2.8.9",
     "@types/express": "^4.17.11",

--- a/src/appV2.test.ts
+++ b/src/appV2.test.ts
@@ -275,6 +275,55 @@ describe('Body as Function', () => {
     })
 });
 
+describe('Request Element is Simple Type', () => {
+    test('Send in string', async () => {
+        const seed: RuntimeRequestCollection = {
+            "/test": {
+                path: "/test",
+                methods: {
+                    POST: {
+                        body: JSON.stringify(true),
+                        status: 200
+                    }
+                }
+            }
+        }
+
+        const app = appFactory(seed);
+        expect(app).toBeDefined();
+
+        var response = await request(app).post('/test?id=2').send("test");
+
+        expect(response.body).toEqual(true);
+    })
+
+    test('Send in string as JSON', async () => {
+        const seed: RuntimeRequestCollection = {
+            "/test": {
+                path: "/test",
+                methods: {
+                    POST: {
+                        body: JSON.stringify(true),
+                        status: 200
+                    }
+                }
+            }
+        }
+
+        const app = appFactory(seed);
+        expect(app).toBeDefined();
+
+        var response = await request(app)
+                            .post('/test?id=2')
+                            .set('Content-type', 'application/json')
+                            .send("test");
+
+        console.log(response);
+
+        expect(response.body).toEqual(true);
+    })
+});
+
 describe('isRuntimeRequestMethodBodyCollection', () => {
     test('is true for valid object', () => {
         const seed: RuntimeRequestCollection = {

--- a/src/appV2.test.ts
+++ b/src/appV2.test.ts
@@ -318,8 +318,6 @@ describe('Request Element is Simple Type', () => {
                             .set('Content-type', 'application/json')
                             .send("test");
 
-        console.log(response);
-
         expect(response.body).toEqual(true);
     })
 });

--- a/src/appV2.test.ts
+++ b/src/appV2.test.ts
@@ -275,28 +275,7 @@ describe('Body as Function', () => {
     })
 });
 
-describe('Request Element is Simple Type', () => {
-    test('Send in string', async () => {
-        const seed: RuntimeRequestCollection = {
-            "/test": {
-                path: "/test",
-                methods: {
-                    POST: {
-                        body: JSON.stringify(true),
-                        status: 200
-                    }
-                }
-            }
-        }
-
-        const app = appFactory(seed);
-        expect(app).toBeDefined();
-
-        var response = await request(app).post('/test?id=2').send("test");
-
-        expect(response.body).toEqual(true);
-    })
-
+describe('Request Body is Simple Type', () => {
     test('Send in string as JSON', async () => {
         const seed: RuntimeRequestCollection = {
             "/test": {
@@ -316,7 +295,7 @@ describe('Request Element is Simple Type', () => {
         var response = await request(app)
                             .post('/test?id=2')
                             .set('Content-type', 'application/json')
-                            .send("test");
+                            .send('"test"');
 
         expect(response.body).toEqual(true);
     })

--- a/src/appV2.ts
+++ b/src/appV2.ts
@@ -1,4 +1,3 @@
-import bodyParser from 'body-parser';
 import Chance from 'chance';
 import cors from 'cors';
 import express, { Request, Response } from 'express';
@@ -110,7 +109,7 @@ export const appFactory = (runtimeCollection?: RuntimeRequestCollection) => {
     const app = express();
 
     app.use(cors());
-    app.use(bodyParser.json());
+    app.use(express.json());
 
     app.get('/', (_req, res) => res.send(sortKeys(runtimeRequestCollection, { deep: true })));
 

--- a/src/appV2.ts
+++ b/src/appV2.ts
@@ -109,7 +109,9 @@ export const appFactory = (runtimeCollection?: RuntimeRequestCollection) => {
     const app = express();
 
     app.use(cors());
-    app.use(express.json());
+    app.use(express.json({
+        strict: false
+    }));
 
     app.get('/', (_req, res) => res.send(sortKeys(runtimeRequestCollection, { deep: true })));
 


### PR DESCRIPTION
Motivation
---
 - See Issue #13 
 - We have an API we are trying to mock that accepts simple types in POST requests

Modification
---
 - Turned off strict validation for body-parser
 - Updated to use new body-parse and express.json versus deprecated bodyParse.json() callout
 - Added a test to validate simple types work correctly
 - Removed explicit body-parser install now that its included in this version of express

FIXES #13 

https://centeredge.atlassian.net/browse/SWS-4913
