### PR TITLE
Fix using a function for status field (PHNX-8691)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centeredgesoft/runtime-mock-routes",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "",
   "main": "build/index.js",
   "scripts": {

--- a/src/appV2.ts
+++ b/src/appV2.ts
@@ -48,7 +48,7 @@ export interface RequestParameters {
 
 export const isRuntimeRequestMethodBody = (obj: any): obj is RuntimeRequestMethodBody => {
     try {
-        return !!obj.body && (!obj.status || !isNaN(Number(obj.status)))
+        return !!obj.body && (!obj.status || typeof obj.status === 'function' || !isNaN(Number(obj.status)))
     } catch (_) {
         return false;
     }


### PR DESCRIPTION
Motivation
--------

The status field on a mocked route is supposed to be able to be a function. This lets you return different status codes from the mocked route depending on the input. However, setting it to a function currently fails.

Modifications
---------

Updated check to allow status to be a function

Added tests

https://centeredge.atlassian.net/browse/PHNX-8691
