### PR TITLE
Support more content types (PHNX-8794)

### DIFF
--- a/src/appV2.ts
+++ b/src/appV2.ts
@@ -110,7 +110,8 @@ export const appFactory = (runtimeCollection?: RuntimeRequestCollection) => {
 
     app.use(cors());
     app.use(express.json({
-        strict: false
+        strict: false,
+        type: ['application/json', 'application/*+json', 'text/json']
     }));
 
     app.get('/', (_req, res) => res.send(sortKeys(runtimeRequestCollection, { deep: true })));


### PR DESCRIPTION
Motivation
---------

Currently, mocks only parse the body of a request if the request has a content type of "application/json". Some requests to Advantage have a content type of "application/json-patch+json". When mocking against those requests, the request body is not parsed.

Modfications
---------

Added support for more content types

https://centeredge.atlassian.net/browse/PHNX-8794
