### PR TITLE
Add `raw` option (PHNX-16792)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@centeredgesoft/runtime-mock-routes",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@centeredgesoft/runtime-mock-routes",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "license": "MIT",
       "dependencies": {
         "chance": "^1.1.7",

--- a/src/appV2.test.ts
+++ b/src/appV2.test.ts
@@ -275,6 +275,36 @@ describe('Body as Function', () => {
     })
 });
 
+describe('Body returns quoted JSON when sending raw', () => {
+    test('Return JSON stringified string with quotes', async () => {
+        const seed: RuntimeRequestCollection = {
+            "/test": {
+                path: "/test",
+                methods: {
+                    GET: {
+                        body: function(rp: RequestParameters) { return JSON.stringify(`"<p>Test</p>"`) },
+                        status: 200,
+                        headers: () => { return { 'Content-Type': 'application/json; charset=utf-8' } },
+                        raw: true
+                    }
+                }
+            }
+        }
+
+        const app = appFactory(seed);
+        expect(app).toBeDefined();
+
+        var response = await request(app).get('/test');
+
+        expect(response.body).toEqual(`"<p>Test</p>"`);
+        expect(response.body).toHaveLength(13)
+        expect(response.body[0]).toBe(`"`);
+        expect(response.body[1]).toBe(`<`);
+        expect(response.body[11]).toBe(`>`);
+        expect(response.body[12]).toBe(`"`);
+    })
+});
+
 describe('Request Body is Simple Type', () => {
     test('Send in string as JSON', async () => {
         const seed: RuntimeRequestCollection = {

--- a/src/appV2.ts
+++ b/src/appV2.ts
@@ -37,6 +37,7 @@ export interface RuntimeRequestMethodBody {
     body: any;
     status?: any;
     headers?: any;
+    raw?: boolean;
 }
 
 export interface RequestParameters {
@@ -218,7 +219,7 @@ export const appFactory = (runtimeCollection?: RuntimeRequestCollection) => {
                 const status = typeof method.status === 'function'
                  ? method.status(tokenParams)
                  : method.status
-                
+
                 res.status(status);
             }
 
@@ -252,6 +253,10 @@ export const appFactory = (runtimeCollection?: RuntimeRequestCollection) => {
             const result = template(tokenParams)
 
             try {
+                 if (method.raw) {
+                    return res.send(result);
+                }
+
                 const jsonResult = JSON.parse(result);
                 return res.send(jsonResult);
             } catch (_) {


### PR DESCRIPTION
# Motivations
In a rare scenarios we need the ability to respond with a raw response and skip the final json serialization

# Modifications
- Add a `raw` option defaulted to false which will skip serializing our body before sending it
- Add a test for it

https://centeredge.atlassian.net/browse/PHNX-16792
