### PR TITLE
Pass status to Express as a number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centeredgesoft/runtime-mock-routes",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "description": "",
   "main": "build/index.js",
   "scripts": {

--- a/src/appV2.ts
+++ b/src/appV2.ts
@@ -245,9 +245,13 @@ export const appFactory = (runtimeCollection?: RuntimeRequestCollection) => {
             }
 
             if (method.status) {
-                const status = typeof method.status === 'function'
-                 ? method.status(tokenParams)
-                 : method.status
+                let status = typeof method.status === 'function'
+                    ? method.status(tokenParams)
+                    : method.status
+
+                if (typeof status === 'string') {
+                    status = parseInt(status);
+                }
 
                 res.status(status);
             }


### PR DESCRIPTION
Motivation
---
Express 5 is throwing an error if status is passed as a string, but we used to accept this with Express 4.

Modifications
---
Cast strings to integers before forwarding to Express.