### PR TITLE
Tune root request logging & log response headers (PHNX-17377)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@centeredgesoft/runtime-mock-routes",
-  "version": "2.10.0",
+  "version": "2.10.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/appV2.ts
+++ b/src/appV2.ts
@@ -121,20 +121,30 @@ export const appFactory = (runtimeCollection?: RuntimeRequestCollection) => {
         const logger = logs.getLogger('mock-requests-logger');
 
         app.use((req, res, next) => {
-            // log the request
+
+            let severity = SeverityNumber.INFO;
+            let severityText = 'INFO';
+
+            // Log root requests as trace
+            if (req.path === '/') {
+                severity = SeverityNumber.TRACE;
+                severityText = 'TRACE';
+            }
+
+            // Log the request
             logger.emit({
-                severityNumber: SeverityNumber.INFO,
-                severityText: 'INFO',
+                severityNumber: severity,
+                severityText: severityText,
                 body: `Request ${req.path}`,
                 attributes: {
                     'http.headers': req.headers,
                     'http.method': req.method,
                     'http.url': req.url,
-                    'http.request_body': req.body,
+                    'http.request_body': req.body
                 }
             });
 
-            // log the response
+            // Log the response
             const originalSend = res.send;
             let firstSend = true;
             res.send = function (body) {
@@ -143,14 +153,15 @@ export const appFactory = (runtimeCollection?: RuntimeRequestCollection) => {
                     firstSend = false;
 
                     logger.emit({
-                        severityNumber: SeverityNumber.INFO,
-                        severityText: 'INFO',
+                        severityNumber: severity,
+                        severityText: severityText,
                         body: `Response ${req.path}`,
                         attributes: {
                             'http.status_code': res.statusCode,
                             'http.method': req.method,
                             'http.url': req.url,
                             'http.response_body': body,
+                            'http.headers': res.getHeaders()
                         }
                     });
                 }
@@ -305,7 +316,7 @@ export const appFactory = (runtimeCollection?: RuntimeRequestCollection) => {
     app.put(/\/.*/, catchAllHandler);
     app.patch(/\/.*/, catchAllHandler);
     app.delete(/\/.*/, catchAllHandler);
-    
+
     Object.defineProperty(app, 'runtimeRequestCollection', {
         get: () => {
             return cloneDeep(runtimeRequestCollection);

--- a/src/appV2.ts
+++ b/src/appV2.ts
@@ -137,10 +137,10 @@ export const appFactory = (runtimeCollection?: RuntimeRequestCollection) => {
                 severityText: severityText,
                 body: `Request ${req.path}`,
                 attributes: {
-                    'http.headers': req.headers,
                     'http.method': req.method,
                     'http.url': req.url,
-                    'http.request_body': req.body
+                    'http.request_body': req.body,
+                    'http.request_headers': req.headers,
                 }
             });
 
@@ -161,7 +161,7 @@ export const appFactory = (runtimeCollection?: RuntimeRequestCollection) => {
                             'http.method': req.method,
                             'http.url': req.url,
                             'http.response_body': body,
-                            'http.headers': res.getHeaders()
+                            'http.response_headers': res.getHeaders()
                         }
                     });
                 }


### PR DESCRIPTION
# Motivations
Right now our aspire hosts use `/` as a health check, which is nice but clutters logs while debugging our mocks

# Modifications
- Treat `/` requests as a trace in logging, this will make it easier to filter out
- Add header response logging

https://centeredge.atlassian.net/browse/PHNX-17377
